### PR TITLE
Name main function for React support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,21 @@ Install this package using `npm`:
 
 Assuming you already have `Remarkable` installed, one way to use would be like so:
 
+**CommonJS**
 ```javascript
 var Remarkable = require('remarkable');
 var plugin = require('remarkable-katex');
 var md = new Remarkable();
 md.use(plugin);
+```
+
+**ES6**
+```javascript
+import { Remarkable } from 'remarkable';
+import rkatex from 'remarkable-katex';
+
+var md = new Remarkable();
+md.use(rkatex);
 ```
 
 # Configuration

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
  * Plugin for Remarkable Markdown processor which transforms $..$ and $$..$$ sequences into math HTML using the
  * Katex package.
  */
-function rkatex(md, options) {
+const rkatex = (md, options) => {
   const dollar = '$';
   const opts = options || {};
   const delimiter = opts.delimiter || dollar;

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
  * Plugin for Remarkable Markdown processor which transforms $..$ and $$..$$ sequences into math HTML using the
  * Katex package.
  */
-module.exports = (md, options) => {
+function rkatex(md, options) {
   const dollar = '$';
   const opts = options || {};
   const delimiter = opts.delimiter || dollar;
@@ -132,3 +132,5 @@ module.exports = (md, options) => {
   md.renderer.rules.katex = (tokens, idx) => renderKatex(tokens[idx].content, tokens[idx].block);
   md.renderer.rules.katex.delimiter = delimiter;
 };
+
+module.exports = rkatex;


### PR DESCRIPTION
There doesn't seem to be any support for React, since the function isn't named in the export. Also, since the name includes a dash (-), it doesn't import correctly, anyway.

With this, you should be able to import the plugin like this:

```js
   import rkatex from 'remarkable-katex';
```